### PR TITLE
Add users to define charging station type

### DIFF
--- a/charging_stations.add.xml
+++ b/charging_stations.add.xml
@@ -5,12 +5,63 @@
 
 <additional xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/additional_file.xsd">
     <!-- StoppingPlaces -->
-    <chargingStation id="cs_0" lane="E5_3" startPos="8.05" endPos="28.05" chargeType="fuel"/>
-    <chargingStation id="cs_1" lane="E5_2" startPos="8.05" endPos="28.05" chargeType="fuel"/>
-    <chargingStation id="cs_2" lane="E5_1" startPos="8.05" endPos="28.05" chargeType="fuel"/>
-    <chargingStation id="cs_3" lane="E8_0" startPos="30.98" endPos="50.98" chargeType="fuel"/>
-    <chargingStation id="cs_4" lane="E8_1" startPos="30.98" endPos="50.98" chargeType="fuel"/>
-    <chargingStation id="cs_5" lane="E8_2" startPos="30.98" endPos="50.98" chargeType="fuel"/>
-    <chargingStation id="cs_6" lane="E8_3" startPos="30.98" endPos="50.98" chargeType="fuel"/>
-    <chargingStation id="cs_7" lane="E5_0" startPos="8.05" endPos="28.05" chargeType="fuel"/>
+    <chargingStation id="cs_0" lane="E5_3" startPos="8.05" endPos="28.05" chargeType="fuel" fuelType="hydrogen" />
+    <chargingStation id="cs_1" lane="E5_2" startPos="8.05" endPos="28.05" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_2" lane="E5_1" startPos="8.05" endPos="28.05" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_3" lane="E8_0" startPos="30.98" endPos="50.98" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_4" lane="E8_1" startPos="30.98" endPos="50.98" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_5" lane="E8_2" startPos="30.98" endPos="50.98" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_6" lane="E8_3" startPos="30.98" endPos="50.98" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_7" lane="E5_0" startPos="8.05" endPos="28.05" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_8" lane="E1_0" startPos="15.98" endPos="35.98" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_9" lane="E1_1" startPos="15.98" endPos="35.98" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_10" lane="E1_2" startPos="15.98" endPos="35.98" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_11" lane="E1_3" startPos="15.98" endPos="35.98" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_12" lane="E10_0" startPos="7.50" endPos="27.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_13" lane="E10_1" startPos="7.50" endPos="27.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_14" lane="E10_2" startPos="7.50" endPos="27.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_15" lane="E10_3" startPos="7.50" endPos="27.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_16" lane="E13_0" startPos="3.20" endPos="23.20" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_17" lane="E13_1" startPos="3.20" endPos="23.20" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_18" lane="E13_2" startPos="3.20" endPos="23.20" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_19" lane="E13_3" startPos="3.20" endPos="23.20" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_20" lane="E16_0" startPos="2.50" endPos="22.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_21" lane="E16_1" startPos="2.50" endPos="22.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_22" lane="E16_2" startPos="2.50" endPos="22.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_23" lane="E16_3" startPos="2.50" endPos="22.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_24" lane="E19_0" startPos="1.10" endPos="21.10" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_25" lane="E19_1" startPos="1.10" endPos="21.10" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_26" lane="E19_2" startPos="1.10" endPos="21.10" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_27" lane="E22_0" startPos="2.30" endPos="22.30" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_28" lane="E22_1" startPos="2.30" endPos="22.30" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_29" lane="E22_2" startPos="2.30" endPos="22.30" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_30" lane="E22_3" startPos="2.30" endPos="22.30" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_31" lane="E25_0" startPos="2.40" endPos="22.40" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_32" lane="E25_1" startPos="2.40" endPos="22.40" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_33" lane="E25_2" startPos="2.40" endPos="22.40" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_34" lane="E25_3" startPos="2.40" endPos="22.40" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_35" lane="E28_0" startPos="1.10" endPos="21.10" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_36" lane="E28_1" startPos="1.10" endPos="21.10" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_37" lane="E31_0" startPos="20.50" endPos="40.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_38" lane="E31_1" startPos="20.50" endPos="40.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_39" lane="E31_2" startPos="20.50" endPos="40.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_40" lane="E31_3" startPos="20.50" endPos="40.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_41" lane="E34_0" startPos="8.50" endPos="28.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_42" lane="E34_1" startPos="8.50" endPos="28.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_43" lane="E34_2" startPos="8.50" endPos="28.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_44" lane="E34_3" startPos="8.50" endPos="28.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_45" lane="E37_0" startPos="15.50" endPos="35.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_46" lane="E37_1" startPos="15.50" endPos="35.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_47" lane="E37_2" startPos="15.50" endPos="35.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_48" lane="E37_3" startPos="15.50" endPos="35.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_49" lane="E40_0" startPos="9.50" endPos="29.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_50" lane="E40_1" startPos="9.50" endPos="29.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_51" lane="E40_2" startPos="9.50" endPos="29.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_52" lane="E40_3" startPos="9.50" endPos="29.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_53" lane="E43_0" startPos="2.20" endPos="22.20" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_54" lane="E43_1" startPos="2.20" endPos="22.20" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_55" lane="E46_0" startPos="3.50" endPos="23.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_56" lane="E46_1" startPos="3.50" endPos="23.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_57" lane="E46_2" startPos="3.50" endPos="23.50" chargeType="fuel" fuelType="petrol" />
+    <chargingStation id="cs_58" lane="E46_3" startPos="3.50" endPos="23.50" chargeType="fuel" fuelType="petrol" />
 </additional>

--- a/h2mob/h2mob/main.py
+++ b/h2mob/h2mob/main.py
@@ -4,7 +4,7 @@ from typing import Annotated
 from h2mob.services.generate_scenario import get_scenario_generator_service
 from h2mob.services.simulation import get_simulation_service
 from h2mob.settings.generator_config import get_scenario_conf
-from h2mob.settings.simulation import get_simulation_config
+from h2mob.settings.simulation import SimulationConfig, get_simulation_config
 
 import typer
 
@@ -39,8 +39,8 @@ def run(
     scenario_path: Annotated[Path, typer.Argument()],
     percent_of_hydrogen_cars: Annotated[float, typer.Argument()],
 ) -> None:
-    config = get_simulation_config()
-    service = get_simulation_service(
+    config: SimulationConfig = get_simulation_config()
+    service: Service = get_simulation_service(
         logger=logger,
         percent_of_hydrogen_cars=percent_of_hydrogen_cars,
         simulation_config=config,

--- a/h2mob/h2mob/settings/simulation.py
+++ b/h2mob/h2mob/settings/simulation.py
@@ -5,8 +5,8 @@ from h2mob.settings import general
 
 class SimulationConfig(general.GeneralConfig):
     fuel_threshold_liters: int = 20
-    hydrogen_vehicle_colour: tuple[int, int, int, int] = (255, 0, 0, 255)
-    petrol_vehicle_colour: tuple[int, int, int, int] = (0, 255, 0, 255)
+    hydrogen_vehicle_colour: tuple[int, int, int, int] = (0, 255, 0, 255)
+    petrol_vehicle_colour: tuple[int, int, int, int] = (255, 0, 0, 255)
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
Users can define the fuel type of charging stations. The runner will route vehicles to the nearest charging stations according to the vehicle's fuel type. 